### PR TITLE
Make it possible to sanity-compile project

### DIFF
--- a/examples/engage/engage.go
+++ b/examples/engage/engage.go
@@ -19,7 +19,7 @@ func main() {
 	}
 
 	token := os.Args[1]
-	distinctId := os.Args[2]
+	distinctID := os.Args[2]
 
 	op := &mixpanel.Operation{Name: os.Args[3], Values: map[string]interface{}{}}
 	if op.Name == "" {
@@ -36,7 +36,7 @@ func main() {
 	}
 
 	mp := mixpanel.NewMixpanel(token)
-	err := mp.Engage(distinctId, map[string]interface{}{}, op)
+	err := mp.Engage(distinctID, map[string]interface{}{}, op)
 	if err != nil {
 		fmt.Println("Error occurred:", err)
 	}

--- a/examples/track/track.go
+++ b/examples/track/track.go
@@ -21,9 +21,9 @@ func main() {
 	token := os.Args[1]
 	event := os.Args[2]
 
-	var distinctId string
+	var distinctID string
 	if len(os.Args) >= 4 {
-		distinctId = os.Args[3]
+		distinctID = os.Args[3]
 	}
 
 	props := map[string]interface{}{}
@@ -37,7 +37,7 @@ func main() {
 	}
 
 	mp := mixpanel.NewMixpanel(token)
-	err := mp.Track(distinctId, event, props)
+	err := mp.Track(distinctID, event, props)
 	if err != nil {
 		fmt.Println("Error occurred:", err)
 	}


### PR DESCRIPTION
When both the example files were in the same directory, their two main()
methods conflicted, making in impossible to run 'go build ./...' which in turn made it harder to figure out if everything compiles.

This PR moves each file to its own directory.