### PR TITLE
Reduce number of golint complaints

### DIFF
--- a/mixpanel.go
+++ b/mixpanel.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	apiBaseUrl = "http://api.mixpanel.com"
+	apiBaseURL = "http://api.mixpanel.com"
 	library    = "timehop/go-mixpanel"
 )
 
@@ -36,14 +36,14 @@ type Operation struct {
 func NewMixpanel(token string) *Mixpanel {
 	return &Mixpanel{
 		Token:   token,
-		BaseUrl: apiBaseUrl,
+		BaseUrl: apiBaseURL,
 	}
 }
 
 // Track sends event data with optional metadata.
-func (m *Mixpanel) Track(distinctId string, event string, props Properties) error {
-	if distinctId != "" {
-		props["distinct_id"] = distinctId
+func (m *Mixpanel) Track(distinctID string, event string, props Properties) error {
+	if distinctID != "" {
+		props["distinct_id"] = distinctID
 	}
 	props["token"] = m.Token
 	props["mp_lib"] = library
@@ -53,9 +53,9 @@ func (m *Mixpanel) Track(distinctId string, event string, props Properties) erro
 }
 
 // Engage updates profile data.
-func (m *Mixpanel) Engage(distinctId string, props Properties, op *Operation) error {
-	if distinctId != "" {
-		props["$distinct_id"] = distinctId
+func (m *Mixpanel) Engage(distinctID string, props Properties, op *Operation) error {
+	if distinctID != "" {
+		props["$distinct_id"] = distinctID
 	}
 	props["$token"] = m.Token
 	props["mp_lib"] = library


### PR DESCRIPTION
I ran `golint ./...` using Go 1.4 and got a few complaints.

`golint` likes all caps for abbreviations and things that are pronounced like abbreviations (e.g.
ID and URL).

This doesn't change the exported BaseUrl on the Mixpanel type, since callers are probably using that.
It would take a bit more work to deprecate it. Is this something that you'd be interested in accepting a pull request for?

Since the library isn't versioned beyond commit SHAs I'm not sure how deprecation would work (i.e. when would one delete the old value?).