### PR TITLE
Generate tracking url with redirect

### DIFF
--- a/mixpanel.go
+++ b/mixpanel.go
@@ -64,6 +64,31 @@ func (m *Mixpanel) Engage(distinctId string, props Properties, op *Operation) er
 	return m.makeRequestWithData("GET", "engage", props)
 }
 
+// RedirectURL returns a url that, when clicked, will track the given data and then redirect to provided url.
+func (m *Mixpanel) RedirectURL(distinctId, event, uri string, props Properties) (string, error) {
+	if distinctId != "" {
+		props["$distinct_id"] = distinctId
+	}
+	props["$token"] = m.Token
+	props["mp_lib"] = library
+
+	data := map[string]interface{}{"event": event, "properties": props}
+	json, err := json.Marshal(data)
+	if err != nil {
+		return "", err
+	}
+
+	params := map[string]string{
+		"data":     base64.StdEncoding.EncodeToString(json),
+		"redirect": uri,
+	}
+	query := url.Values{}
+	for k, v := range params {
+		query[k] = []string{v}
+	}
+	return fmt.Sprintf("%s/%s?%s", m.BaseUrl, "track", query.Encode()), nil
+}
+
 func (m *Mixpanel) makeRequest(method string, endpoint string, paramMap map[string]string) error {
 	var (
 		err error

--- a/mixpanel_test.go
+++ b/mixpanel_test.go
@@ -1,0 +1,25 @@
+package mixpanel
+
+import "testing"
+
+func TestRedirectURL(t *testing.T) {
+	mp := NewMixpanel("abc")
+	props := Properties{
+		"a": "apples",
+		"b": "bananas",
+		"c": "cherries",
+	}
+
+	actualURI, err := mp.RedirectURL("12345", "Clicked through", "http://example.com", props)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// data decodes to:
+	// "{\"event\":\"Clicked through\",\"properties\":{\"$distinct_id\":\"12345\",\"$token\":\"abc\",\"a\":\"apples\",\"b\":\"bananas\",\"c\":\"cherries\",\"mp_lib\":\"timehop/go-mixpanel\"}}"
+	expectedURI := `http://api.mixpanel.com/track?data=eyJldmVudCI6IkNsaWNrZWQgdGhyb3VnaCIsInByb3BlcnRpZXMiOnsiJGRpc3RpbmN0X2lkIjoiMTIzNDUiLCIkdG9rZW4iOiJhYmMiLCJhIjoiYXBwbGVzIiwiYiI6ImJhbmFuYXMiLCJjIjoiY2hlcnJpZXMiLCJtcF9saWIiOiJ0aW1laG9wL2dvLW1peHBhbmVsIn19&redirect=http%3A%2F%2Fexample.com`
+
+	if actualURI != expectedURI {
+		t.Errorf("\n got: %s\nwant: %s\n", actualURI, expectedURI)
+	}
+}


### PR DESCRIPTION
Under some circumstances (e.g. when sending emails to customers) we need to create a url that will (a) track some data, and (b) redirect to a url of our choice.

Note that I named the `distinctId` to match the other code in the file. If you accept the [golint PR](https://github.com/timehop/go-mixpanel/pull/4) let me know and I'll update this PR to fix the style of the variable.