### PR TITLE
Fix incorrect API call for unset property

### DIFF
--- a/mixpanel.go
+++ b/mixpanel.go
@@ -59,7 +59,15 @@ func (m *Mixpanel) Engage(distinctId string, props Properties, op *Operation) er
 	}
 	props["$token"] = m.Token
 	props["mp_lib"] = library
-	props[op.Name] = op.Values
+	if op.Name == "$unset" {
+		keys := []interface{}{}
+		for key, _ := range op.Values {
+			keys = append(keys, key)
+		}
+		props[op.Name] = keys
+	} else {
+		props[op.Name] = op.Values
+	}
 
 	return m.makeRequestWithData("GET", "engage", props)
 }


### PR DESCRIPTION
Logically (though it didn't occur to me until I needed it), $unset only needs the names of the properties, not name-value pairs.